### PR TITLE
feat: implement configurable role-based authentication

### DIFF
--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -5,6 +5,8 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Security
 from starlette.status import HTTP_403_FORBIDDEN
 
+from app.config import settings
+
 from .schemas import TokenInfo, User
 from .security import openid_connect
 
@@ -35,27 +37,6 @@ def get_current_user(token_info: Annotated[TokenInfo, Depends(require_auth)]) ->
         User: Current authenticated user
     """
     return token_info.user
-
-
-def require_admin(token_info: Annotated[TokenInfo, Depends(require_auth)]) -> TokenInfo:
-    """
-    Require admin role for endpoint access.
-
-    Args:
-        token_info: Validated token information
-
-    Returns:
-        TokenInfo: Validated token information
-
-    Raises:
-        HTTPException: If user lacks admin role
-    """
-    if not token_info.user.has_role("admin"):
-        raise HTTPException(
-            status_code=HTTP_403_FORBIDDEN, detail="Admin role required"
-        )
-
-    return token_info
 
 
 def require_roles(*required_roles: str):
@@ -109,6 +90,4 @@ def require_all_roles(*required_roles: str):
 
 
 # Common role-based dependencies
-require_user = require_auth  # Alias for basic authentication
-require_manager = require_roles("manager", "admin")
-require_viewer = require_roles("viewer", "manager", "admin")
+require_user = require_roles(settings.required_role)

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,10 @@ class Settings(BaseSettings):
     auth_token_endpoint_url: str
     auth_oidc_url: str
 
+    # Role-based access control
+    required_role: Annotated[str, Field(default="calUsers")]
+    role_claim_path: Annotated[str, Field(default="role")]
+
     # OAuth2 Client Configuration (for Swagger UI authorization)
     oauth_client_id: str | None = None
     oauth_scopes: Annotated[str, Field(default="openid")]


### PR DESCRIPTION
## Summary
- Add configurable role settings (`required_role`, `role_claim_path`) to match frontend expectations
- Support flexible JWT claim paths like "cognito:groups" for AWS Cognito integration
- Handle both string and array role formats in JWT tokens
- Use existing `require_roles()` for cleaner dependency injection
- All protected routes now require configured role (default: "calUsers")

## Changes
- **config.py**: Added `required_role` and `role_claim_path` settings
- **schemas.py**: Enhanced role extraction with `extract_roles_from_claims()` utility
- **dependencies.py**: Simplified role checking using existing infrastructure
- **main.py**: Updated protected dependencies to use configurable role

## Test Plan
- [ ] Verify JWT tokens with "cognito:groups" claim are properly parsed
- [ ] Test both string and array role formats in tokens
- [ ] Confirm all protected routes require the configured role
- [ ] Validate error messages for missing roles
- [ ] Test environment variable configuration

🤖 Generated with [Claude Code](https://claude.ai/code)